### PR TITLE
Use GNUInstallDirs to specify multilib specific dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 2.6)
 project(inih)
 
-add_subdirectory(lib)
+INCLUDE(GNUInstallDirs)
+
 add_subdirectory(include)
+add_subdirectory(lib)
 
 if( CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" )
   set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-fPIC")
@@ -10,4 +12,4 @@ endif( CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" )
 
 configure_file(inih.pc.in inih.pc @ONLY)
 configure_file(inihcpp.pc.in inihcpp.pc @ONLY)
-install(FILES ${CMAKE_BINARY_DIR}/inih.pc ${CMAKE_BINARY_DIR}/inihcpp.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+install(FILES ${CMAKE_BINARY_DIR}/inih.pc ${CMAKE_BINARY_DIR}/inihcpp.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,5 +18,5 @@ else(BUILD_SHARED_LIBS)
   add_library(inihcpp STATIC ini.c INIReader.cpp)
 endif(BUILD_SHARED_LIBS)
 
-install(TARGETS inih inihcpp DESTINATION lib)
+install(TARGETS inih inihcpp DESTINATION ${CMAKE_INSTALL_LIBDIR})
 


### PR DESCRIPTION
Helps in building on arches where default baselib is lib64

Signed-off-by: Khem Raj <raj.khem@gmail.com>