### PR TITLE
include: install header files without prefix dir inih

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,1 +1,1 @@
-install(FILES ini.h INIReader.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include/inih)
+install(FILES ini.h INIReader.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)


### PR DESCRIPTION
The other flavor of inih which adapted by Fedora and Ubuntu installs
header files to /usr/include directly. And xfsprogs 5.10.0 also checks
ini.h without extra search path and fails. So install header files
without prefix dir inih.

Signed-off-by: Kai Kang <kai.kang@windriver.com>